### PR TITLE
Guards fixed on tree simulations for clads. 

### DIFF
--- a/phywppl/models/clads0-multiplier.wppl
+++ b/phywppl/models/clads0-multiplier.wppl
@@ -14,30 +14,20 @@
  * @return M
  */
  
- var speciation_decisions = function(lambda, alpha, sigma, multip)
-  {
-        display("speciation")
-        var multip1 = multip * Math.exp(gaussian( {mu: alpha, sigma: sigma}))  // Draw and calc new multiplier set for daughter1
-        var multip2 = multip * Math.exp(gaussian( {mu: alpha, sigma: sigma}))  // Draw and calc new multiplier set for daughter2
-        var lambda1 = lambda_0 * multip1                                // Calculate new lambda for daughter1
-        var lambda2 = lambda_0 * multip2                                // Calculate new lambda for daughter2
-        display([lambda1, lambda2, multip1, multip2])
-        return([lambda1, lambda2, multip1, multip2])
- }
  
-var M_clads0multipGoesUndetected = function( startTime, lambda, alpha, sigma, rho, max_M, multip )
+var M_clads0multipGoesUndetected = function( startTime, lambda0, lambda, alpha, sigma, rho, max_M, multip )
 {
     if ( max_M == 0 ) return NaN
     // We need to survive twice
-    if (!clads0multipGoesUndetected( startTime, lambda, alpha, sigma, rho, multip ) &&
-	!clads0multipGoesUndetected( startTime, lambda, alpha, sigma, rho, multip )) return 1
-    else return(1 + M_clads0multipGoesUndetected( startTime, lambda, alpha, sigma, rho, max_M - 1, multip ))
+    if (!clads0multipGoesUndetected( startTime, lambda0, lambda, alpha, sigma, rho, multip ) &&
+	!clads0multipGoesUndetected( startTime, lambda0, lambda, alpha, sigma, rho, multip )) return 1
+    else return(1 + M_clads0multipGoesUndetected( startTime, lambda0, lambda, alpha, sigma, rho, max_M - 1, multip ))
 }
 
 
 // Forward simulation from a starting time, returning whether the lineage goes
 // undetected (true) or is detected (false)
-var clads0multipGoesUndetected = function( startTime, lambda, alpha, sigma, rho, multip )
+var clads0multipGoesUndetected = function( startTime, lambda0, lambda, alpha, sigma, rho, multip )
 {
     // extreme values patch 1/2
     if ( lambda  > phyjs.MAX_LAMBDA )
@@ -66,9 +56,8 @@ var clads0multipGoesUndetected = function( startTime, lambda, alpha, sigma, rho,
     // Speciation; first draw values for daughter lineages and then recurse
         var multip1 = multip * Math.exp(gaussian( {mu: alpha, sigma: sigma}))  // Draw and calc new multiplier set for daughter1
         var multip2 = multip * Math.exp(gaussian( {mu: alpha, sigma: sigma}))  // Draw and calc new multiplier set for daughter2
-        var lambda1 = 0.2 * multip1                                // Calculate new lambda for daughter1
-        var lambda2 = 0.2 * multip2                                // Calculate new lambda for daughter2
-         //       display([lambda1, lambda2, multip1, multip2])
+        var lambda1 = lambda0 * multip1                                // Calculate new lambda for daughter1
+        var lambda2 = lambda0 * multip2                                // Calculate new lambda for daughter2
 	return ( clads0multipGoesUndetected( currentTime, lambda1, alpha, sigma, rho, multip1 )
           && clads0multipGoesUndetected( currentTime, lambda2, alpha, sigma, rho, multip2 ) )
 }
@@ -98,7 +87,7 @@ var clads0multipGoesUndetected = function( startTime, lambda, alpha, sigma, rho,
 var simClaDS0multip = function( tree, lambda_0, alpha, sigma, rho, multip )
 {
     // Simulate process along a branch
-    var simBranch = function( startTime, stopTime, lambda, alpha, sigma, rho, multip )
+    var simBranch = function( startTime, stopTime, lambda0, lambda, alpha, sigma, rho, multip )
     {
 
 	var t1 = startTime - stopTime
@@ -129,8 +118,8 @@ var simClaDS0multip = function( tree, lambda_0, alpha, sigma, rho, multip )
 	// that is sampled, and that lambda2 applies to the undetected side lineage.
         var multip1 = multip * Math.exp(gaussian( {mu: alpha, sigma: sigma}))  // Draw and calc new multiplier set for daughter1
         var multip2 = multip * Math.exp(gaussian( {mu: alpha, sigma: sigma}))  // Draw and calc new multiplier set for daughter2
-        var lambda1 = 0.2 * multip1                                // Calculate new lambda for daughter1
-        var lambda2 = 0.2 * multip2                                // Calculate new lambda for daughter2
+        var lambda1 = lambda0 * multip1                                // Calculate new lambda for daughter1
+        var lambda2 = lambda0 * multip2                                // Calculate new lambda for daughter2
             //    display([lambda1, lambda2, multip1, multip2])
 	var sideUndetected = clads0multipGoesUndetected( currentTime, lambda2, alpha, sigma, rho, multip2 )
 	if ( sideUndetected == false )
@@ -150,8 +139,8 @@ var simClaDS0multip = function( tree, lambda_0, alpha, sigma, rho, multip )
 	{
         var multip1 = multip * Math.exp(gaussian( {mu: alpha, sigma: sigma}))  // Draw and calc new multiplier set for daughter1
         var multip2 = multip * Math.exp(gaussian( {mu: alpha, sigma: sigma}))  // Draw and calc new multiplier set for daughter2
-        var lambda1 = 0.2 * multip1                                // Calculate new lambda for daughter1
-        var lambda2 = 0.2 * multip2                                // Calculate new lambda for daughter2
+        var lambda1 = lambda0 * multip1                                // Calculate new lambda for daughter1
+        var lambda2 = lambda0 * multip2                                // Calculate new lambda for daughter2
              //   display("null")
              //   display([lambda1, lambda2, multip1, multip2])
 	    
@@ -185,8 +174,8 @@ var simClaDS0multip = function( tree, lambda_0, alpha, sigma, rho, multip )
             // Get daughter rates and then recurse
         var multip1 = multip * Math.exp(gaussian( {mu: alpha, sigma: sigma}))  // Draw and calc new multiplier set for daughter1
         var multip2 = multip * Math.exp(gaussian( {mu: alpha, sigma: sigma}))  // Draw and calc new multiplier set for daughter2
-        var lambda1 = 0.2 * multip1                                // Calculate new lambda for daughter1
-        var lambda2 = 0.2 * multip2                                // Calculate new lambda for daughter2
+        var lambda1 = lambda0 * multip1                                // Calculate new lambda for daughter1
+        var lambda2 = lambda0 * multip2                                // Calculate new lambda for daughter2
               //  display([lambda1, lambda2, multip1, multip2])
             var subtree1 = simTree( tree.left,  tree, lambda1, alpha, sigma, rho, multip1 )
             var subtree2 = simTree( tree.right,  tree, lambda2, alpha, sigma, rho, multip2 )

--- a/phywppl/src/webppl-runner.js
+++ b/phywppl/src/webppl-runner.js
@@ -25,9 +25,9 @@
  */
 
 // constants
-const MAX_ITERATIONS = 64
+const MAX_ITERATIONS = 1e6
 const DEFAULT_ITERATIONS = 1
-const DEFAULT_TREE = "src/bisse_32.phyjson"
+const DEFAULT_TREE = ""
 const DEFAULT_RHO = 1.0
 const DEFAULT_NPART = 5000
 require('events').EventEmitter.defaultMaxListeners = MAX_ITERATIONS;
@@ -96,7 +96,7 @@ if (process.argv.length < 4) {
 } else if (process.argv.length == 5) {
     webppl = process.argv[3]
     iterations = process.argv[4]
-    output_error(4, 1)
+    //output_error(4, 1)
     treefile = DEFAULT_TREE
     rho = DEFAULT_RHO
     particles = DEFAULT_NPART
@@ -154,16 +154,54 @@ shell.config.silent = true;
 shell.rm(js + "/" + executable)
 shell.config.silent = false;
 shell.exec(compile_command)
-
+//console.log(compile_command)
 
 
 //Execution
- exec_command = "node " + " --stack-size=" +   stacksize + " " + " --max-old-space-size=4096 " + js + "/" + executable + " " + treefile + " " + rho + " " + particles
-// console.log(exec_command)
+exec_command = "node " + " --stack-size=" +   stacksize + " " + " --max-old-space-size=128 " + js + "/" + executable + " " + treefile + " " + rho + " " + particles
 
- for (i = 0; i < iterations; i++) {
-     shell.exec(exec_command, {async:true} )
- }
+//console.log(exec_command)
 
+function sleep(milliseconds) {
+  const date = Date.now();
+  let currentDate = null;
+  do {
+    currentDate = Date.now();
+  } while (currentDate - date < milliseconds);
+}
+//for (i = 0; i < iterations; i++) {
+i = 0
+var BATCH_SIZE = 64
+while (i < iterations) {
+	// TODO
+    // Execute the iterations asynchronously in batches
+    // idea: 1. run 16 (BATCHSIZE) iterations together
+    // 2. wait until all promises have been resolved
+    // 3. run another batch
+	// Can probably be done by checking if the promise is pending
+    //     https://ourcodeworld.com/articles/read/317/how-to-check-if-a-javascript-promise-has-been-fulfilled-rejected-or-resolved
+	// and then sleeping a bit until it is resolved
+    // function exec(command) {
+    // 	return new Promise((resolve, reject) => shell.exec(command, {async:true}, (code, value, error) => {
+    //         if (error) {
+	// 		return reject(error)
+    //         }
+    //         resolve(value)
+    // 	}))
+	// }
+    // (async () => {
+    //let res = await exec(exec_command)
+    // })()
+    for (var j = 0; j < BATCH_SIZE && i < iterations; j++) {
+	shell.exec(exec_command, {async:true} )
+	i++
+    }
+    // Poor man's asynch
+    if (iterations > BATCH_SIZE && i < iterations) {
+	//waiting 10 sec before next batch
+	sleep(2000)
+    }
+
+}
 
 

--- a/phywppl/tree_simulations/treesim-anadsGBM0.wppl
+++ b/phywppl/tree_simulations/treesim-anadsGBM0.wppl
@@ -15,14 +15,14 @@
 
 // Setting parameters/priors
 var filename = argv["_"][1]
-var startTime = argv["_"][2]
-var lambda0 =  gamma( {shape: 3, scale: 0.1} )
-var stepsize = 0.1
-var sigma = Math.sqrt( 1 / gamma( { shape: 1, scale: 1/0.2 } ) )
+var startTime = argv["_"][2] // Tree age
+var lambda0 = 0.2 // gamma( {shape: 1, scale: 1} )
+var stepsize = 0.2
+var sigma = Math.sqrt( 1 / gamma( { shape: 3, scale: 1/startTime } ) )
 var alpha = Math.exp( gaussian( {mu: 0, sigma: sigma} ) )
 var rho = 1
 // GUARD
-var MAX_LAMBDA = 10;
+var MAX_LAMBDA = 20;
 
 
 var anads0TreeSimulate= function( startTime, lambda, stepsize, alpha, sigma, rho )
@@ -50,6 +50,7 @@ var anads0TreeSimulate= function( startTime, lambda, stepsize, alpha, sigma, rho
  
  var anads0TreeSim = function( startTime, lambda, stepsize, alpha, sigma, rho )
 {
+    display(lambda) //Debugging
     // extreme values patch
     if ( lambda  > MAX_LAMBDA ) {
         var Label = 'Infinity:';                    //Indicate infinite tree on this branch

--- a/phywppl/tree_simulations/treesim-anadsGBM0.wppl
+++ b/phywppl/tree_simulations/treesim-anadsGBM0.wppl
@@ -1,0 +1,135 @@
+/**
+ * Simulation from startTime to the present under AnaDSGBM0, returns observed Tree (without extinctions)
+ *
+ *
+ *
+ * To run the simulation use:
+ * npm run wppl tree_simulations/treesim-anadsGBM0.wppl [N] [OUTPUT_FILENAME] [TREEAGE]
+ *
+ * where [N] is the number of iterations, for example 3
+ *       [OUTPUT_FILENAME] path to output file
+ *       [startTime] Tree age
+ *
+ *
+ */
+
+// Setting parameters/priors
+var filename = argv["_"][1]
+var startTime = argv["_"][2]
+var lambda0 =  gamma( {shape: 3, scale: 0.1} )
+var stepsize = 0.1
+var sigma = Math.sqrt( 1 / gamma( { shape: 1, scale: 1/0.2 } ) )
+var alpha = Math.exp( gaussian( {mu: 0, sigma: sigma} ) )
+var rho = 1
+// GUARD
+var MAX_LAMBDA = 10;
+
+
+var anads0TreeSimulate= function( startTime, lambda, stepsize, alpha, sigma, rho )
+{
+    var Tree = anads0TreeSim( startTime, lambda, stepsize, alpha, sigma, rho );
+    if (Tree == false) {
+        return("No survivors")
+    }
+    var Tree1 = Tree.join(" ") ;
+    var infiniteTree = Tree1.includes("Infinity:")
+    if (infiniteTree == true) {
+        return("Error: Tree has infinite parts - the maximum guard on lambda was activated")
+    }
+    var zeroTree = Tree1.includes("Zero:")
+    if (zeroTree == true) {
+        return("Error: Tree has parts where the minimum guard on lambda was activated")
+    }
+    else {
+        var Tree = Tree.join('') + ';' ;
+        fs.write(filename, Tree);
+        return Tree
+    }
+}
+
+ 
+ var anads0TreeSim = function( startTime, lambda, stepsize, alpha, sigma, rho )
+{
+    display(lambda) //debugging
+    // extreme values patch
+    if ( lambda  > MAX_LAMBDA ) {
+        var Label = 'Infinity:';                    //Indicate infinite tree on this branch
+        var NewickTree = [Label , startTime] ;     // Make start on tree
+        return NewickTree;
+        }
+    if ( lambda == 0.0 ) {
+        var Label = 'Zero:';                        //Indicate lambda=0 on this branch
+        var NewickTree = [Label , startTime] ;     // Make start on tree
+        return NewickTree;
+    }
+    // end extreme values patch
+
+    var timeToSpeciation = exponential( {a: lambda } )
+    var timeToAnagenesis = stepsize
+    
+    if (timeToAnagenesis < timeToSpeciation ){
+    //Anagenetic event
+        var currentTime = startTime - timeToAnagenesis;
+        var internalBranch = timeToAnagenesis;
+        var multip = Math.exp(gaussian( {mu: alpha*stepsize, sigma: sigma*stepsize}))           // Draw and calc new multiplier
+        var lambdaNew = lambda * multip ;                                                                // Calculate new lambda
+        var Tree = anads0TreeSim( currentTime, lambdaNew, stepsize, alpha, sigma, rho );         // Continue along branch
+        if (Tree == false ) {             // Extinct/not sampled
+                return false;
+        }
+        else{
+        var newBranch = Tree[1] + internalBranch;           // Add the two "final" branches
+        var NewickTree = [Tree[0] , newBranch ] ;           // build correct final tree
+        return NewickTree;
+        }
+    }
+    
+    else {
+    //Speciation/cladogenetic event
+        var currentTime = startTime - timeToSpeciation;
+        var internalBranch = timeToSpeciation;          // Length of internal branch leading up to event
+        if ( currentTime < 0 )
+        // We have reached the present
+        {
+            if ( flip( rho ) ){
+                var Label = uniform(0,1) + ':';            //Survived to present, sampled. Start tree: Set random label to leaf node
+                var NewickTree = [Label , startTime] ;     // Make start on tree
+                return NewickTree;
+            }
+            else {
+                return false;    //Survived to present, but not sampled. Remove branch.
+            }
+        }
+        else {
+        // Not reached present: Speciation
+            //Anagenetic "update" event at branching point
+            var delta = timeToSpeciation;
+            var multip = Math.exp(gaussian( {mu: alpha*delta, sigma: sigma*delta}))         // Draw and calc new multiplier
+            var lambdaNew = lambda * multip ;                                                                // Calculate new lambda
+            //Speciation/cladogenetic event
+            var leftTree  = anads0TreeSim( currentTime, lambdaNew, stepsize, alpha, sigma, rho );       // Get back two Newick strings, partial trees
+            var rightTree = anads0TreeSim( currentTime, lambdaNew, stepsize, alpha, sigma, rho );      // Get back two Newick strings, partial trees
+        
+            if (leftTree == false && rightTree == false ) {             // Both sides are extinct/not sampled
+                    return false;
+                }
+            if (rightTree == false) {
+                    var newBranch = leftTree[1] + internalBranch;       // Add the two branches
+                    var NewickTree = [leftTree[0] , newBranch ] ;       // build correct tree without the extinct side
+                    return NewickTree ;
+                }
+            if (leftTree  == false ) {
+                    var newBranch = rightTree[1] + internalBranch;      // Add the two branches
+                    var NewickTree = [rightTree[0] , newBranch ] ;      // build correct tree without the extinct side
+                    return NewickTree ;
+                }
+            else {
+                    var NewickTree = ['(' + leftTree.join('') +',' + rightTree.join('') + ')' + ':' , internalBranch] ;          // Merge trees
+                    return NewickTree ;
+                }
+            }
+    }
+}
+
+
+anads0TreeSimulate( startTime, lambda0, stepsize, alpha, sigma, rho )

--- a/phywppl/tree_simulations/treesim-anadsGBM0.wppl
+++ b/phywppl/tree_simulations/treesim-anadsGBM0.wppl
@@ -50,7 +50,6 @@ var anads0TreeSimulate= function( startTime, lambda, stepsize, alpha, sigma, rho
  
  var anads0TreeSim = function( startTime, lambda, stepsize, alpha, sigma, rho )
 {
-    display(lambda) //debugging
     // extreme values patch
     if ( lambda  > MAX_LAMBDA ) {
         var Label = 'Infinity:';                    //Indicate infinite tree on this branch

--- a/phywppl/tree_simulations/treesim-anadsGBM1.wppl
+++ b/phywppl/tree_simulations/treesim-anadsGBM1.wppl
@@ -1,0 +1,147 @@
+/**
+ * Simulation from startTime to the present under AnaDSGBM1, returns observed Tree (without extinctions)
+ *
+ *
+ *
+ * To run the simulation use:
+ * npm run wppl tree_simulations/treesim-anadsGBM1.wppl [N] [OUTPUT_FILENAME] [TREEAGE]
+ *
+ * where [N] is the number of iterations, for example 3
+ *       [OUTPUT_FILENAME] path to output file
+ *       [startTime] Tree age
+ *
+ */
+
+// Setting parameters/priors
+var filename = argv["_"][1]
+var startTime = argv["_"][2]
+var lambda0 = gamma( {shape: 3, scale: 0.1} )
+var mu = 0.1
+var stepsize = 0.1
+var sigma = Math.sqrt( 1 / gamma( { shape: 1, scale: 1/0.2 } ) )
+var alpha = Math.exp( gaussian( {mu: 0, sigma: sigma} ) )
+var rho = 1
+// GUARDS
+var MAX_LAMBDA = 20
+var MAX_DIV = 20
+
+
+var anads1TreeSimulate= function( startTime, lambda0, stepsize, alpha, sigma, mu, rho  )
+{
+    var Tree = anads1TreeSim( startTime, lambda0, stepsize, alpha, sigma, mu, rho );
+    if (Tree == false) {
+        return("No survivors")
+    }
+    var Tree1 = Tree.join(" ") ;
+    var infiniteTree = Tree1.includes("Infinity:")
+    if (infiniteTree == true) {
+        return("Error: Tree has infinite parts - the maximum guard was activated")
+    }
+    var zeroTree = Tree1.includes("Zero:")
+    if (zeroTree == true) {
+        return("Error: Tree has parts where the minimum guard on lambda was activated")
+    }
+    else {
+        var Tree = Tree.join('') + ';' ;
+        fs.write(filename, Tree);
+        return Tree
+    }
+}
+
+ 
+ var anads1TreeSim = function( startTime, lambda, stepsize, alpha, sigma, mu, rho )
+{
+    display(lambda) //debugging
+    // extreme values patch
+    if ( lambda  > MAX_LAMBDA ) {
+        var Label = 'Infinity:';            //Indicate infinite tree on this branch
+        var NewickTree = [Label , startTime] ;     // Make start on tree
+        return NewickTree;
+        }
+    if ( lambda - mu  > MAX_DIV ) {
+        var Label = 'Infinity:';            //Indicate infinite tree on this branch
+        var NewickTree = [Label , startTime] ;     // Make start on tree
+        return NewickTree;
+        }
+    if ( lambda == 0.0 ) {
+        var Label = 'Zero:';            //Indicate lambda=0 on this branch
+        var NewickTree = [Label , startTime] ;     // Make start on tree
+        return NewickTree;
+    }
+    // end extreme values patch
+
+    var timeToSpeciation = exponential( {a: lambda } )
+    var timeToExtinction = exponential( {a: mu } )
+    var timeToAnagenesis = stepsize
+    
+    if (timeToAnagenesis < timeToSpeciation && timeToAnagenesis < timeToExtinction ){
+    //Anagenetic event
+        var currentTime = startTime - timeToAnagenesis;
+        var internalBranch = timeToAnagenesis;
+        var multip = Math.exp(gaussian( {mu: alpha*stepsize, sigma: sigma*stepsize}))           // Draw and calc new multiplier
+        var lambdaNew = lambda * multip ;                                                                // Calculate new lambda
+        var Tree = anads1TreeSim( currentTime, lambdaNew, stepsize, alpha, sigma, mu, rho );         // Continue along branch
+        if (Tree == false ) {             // Extinct/not sampled
+                return false;
+        }
+        else{
+        var newBranch = Tree[1] + internalBranch;           // Add the two "final" branches
+        var NewickTree = [Tree[0] , newBranch ] ;           // build correct final tree
+        return NewickTree;
+        }
+    }
+        
+    else {
+    //Speciation/cladogenetic event
+    var timeToEvent = Math.min(timeToSpeciation, timeToExtinction);
+    var currentTime = startTime - timeToEvent;
+    var internalBranch = timeToEvent;    // Calculate length of internal branch leading up to event
+    if ( currentTime < 0 )
+    // We have reached the present
+    {
+        if ( flip( rho ) ){
+            var Label = uniform(0,1) + ':';            //Survived to present, sampled. Start tree: Set random label to leaf node
+            var NewickTree = [Label , startTime] ;     // Make start on tree
+            return NewickTree;
+        }
+        else {
+            return false;    //Survived to present, but not sampled. Remove branch.
+        }
+    }
+    if ( timeToExtinction == timeToEvent ) {
+        return false;           //Extinct. Remove branch.
+    }
+    else {
+    // Speciation; first draw values for daughter lineages and then recurse
+        //Anagenetic "update" event at branching point
+        var delta = timeToSpeciation;
+        var multip = Math.exp(gaussian( {mu: alpha*delta, sigma: sigma*delta}))         // Draw and calc new multiplier
+        var lambdaNew = lambda * multip ;                                                                // Calculate new lambda
+        //Speciation/cladogenetic event
+        var leftTree  = anads1TreeSim( currentTime, lambdaNew, stepsize, alpha, sigma, mu, rho );       // Get back two Newick strings, partial trees
+        var rightTree = anads1TreeSim( currentTime, lambdaNew, stepsize, alpha, sigma, mu, rho );      // Get back two Newick strings, partial trees
+        
+        if (leftTree == false && rightTree == false ) {             // Both sides are extinct/not sampled
+                return false;
+            }
+        if (rightTree == false) {
+                var newBranch = leftTree[1] + internalBranch;       // Add the two branches
+                var NewickTree = [leftTree[0] , newBranch ] ;       // build correct tree without the extinct side
+                return NewickTree ;
+            }
+        if (leftTree  == false ) {
+                var newBranch = rightTree[1] + internalBranch;      // Add the two branches
+                var NewickTree = [rightTree[0] , newBranch ] ;      // build correct tree without the extinct side
+                return NewickTree ;
+            }
+        else {
+                var NewickTree = ['(' + leftTree.join('') +',' + rightTree.join('') + ')' + ':' , internalBranch] ;          // Merge trees
+                return NewickTree ;
+            }
+        }
+    }
+    
+}
+
+
+anads1TreeSimulate( startTime, lambda0, stepsize, alpha, sigma, mu, rho )

--- a/phywppl/tree_simulations/treesim-anadsGBM1.wppl
+++ b/phywppl/tree_simulations/treesim-anadsGBM1.wppl
@@ -51,7 +51,6 @@ var anads1TreeSimulate= function( startTime, lambda0, stepsize, alpha, sigma, mu
  
  var anads1TreeSim = function( startTime, lambda, stepsize, alpha, sigma, mu, rho )
 {
-    display(lambda) //debugging
     // extreme values patch
     if ( lambda  > MAX_LAMBDA ) {
         var Label = 'Infinity:';            //Indicate infinite tree on this branch

--- a/phywppl/tree_simulations/treesim-anadsGBM1.wppl
+++ b/phywppl/tree_simulations/treesim-anadsGBM1.wppl
@@ -14,11 +14,11 @@
 
 // Setting parameters/priors
 var filename = argv["_"][1]
-var startTime = argv["_"][2]
-var lambda0 = gamma( {shape: 3, scale: 0.1} )
-var mu = 0.1
-var stepsize = 0.1
-var sigma = Math.sqrt( 1 / gamma( { shape: 1, scale: 1/0.2 } ) )
+var startTime = argv["_"][2] // Tree age
+var lambda0 = 0.2 //gamma( {shape: 1, scale: 1} )
+var mu0 = 0.1 //gamma( {shape: 1, scale: 0.5} )
+var stepsize = 0.2
+var sigma = Math.sqrt( 1 / gamma( { shape: 3, scale: 1/startTime } ) )
 var alpha = Math.exp( gaussian( {mu: 0, sigma: sigma} ) )
 var rho = 1
 // GUARDS
@@ -26,9 +26,9 @@ var MAX_LAMBDA = 20
 var MAX_DIV = 20
 
 
-var anads1TreeSimulate= function( startTime, lambda0, stepsize, alpha, sigma, mu, rho  )
+var anads1TreeSimulate= function( startTime, lambda0, stepsize, alpha, sigma, mu0, rho  )
 {
-    var Tree = anads1TreeSim( startTime, lambda0, stepsize, alpha, sigma, mu, rho );
+    var Tree = anads1TreeSim( startTime, lambda0, stepsize, alpha, sigma, mu0, rho );
     if (Tree == false) {
         return("No survivors")
     }
@@ -51,6 +51,7 @@ var anads1TreeSimulate= function( startTime, lambda0, stepsize, alpha, sigma, mu
  
  var anads1TreeSim = function( startTime, lambda, stepsize, alpha, sigma, mu, rho )
 {
+    display(lambda) //Debugging
     // extreme values patch
     if ( lambda  > MAX_LAMBDA ) {
         var Label = 'Infinity:';            //Indicate infinite tree on this branch
@@ -143,4 +144,4 @@ var anads1TreeSimulate= function( startTime, lambda0, stepsize, alpha, sigma, mu
 }
 
 
-anads1TreeSimulate( startTime, lambda0, stepsize, alpha, sigma, mu, rho )
+anads1TreeSimulate( startTime, lambda0, stepsize, alpha, sigma, mu0, rho )

--- a/phywppl/tree_simulations/treesim-anadsGBM2-viktor.wppl
+++ b/phywppl/tree_simulations/treesim-anadsGBM2-viktor.wppl
@@ -1,0 +1,177 @@
+/**
+ * Simulation from startTime to the present under AnaDSGBM2, returns observed Tree (without extinctions)
+ *
+ *
+ *
+ * To run the simulation use:
+ * npm run wppl tree_simulations/treesim-anadsGBM2.wppl 1 [OUTPUT_TREE] [RHO] [TREE_AGE]
+ *
+ * where 1 is the number of iterations (use external loop if needed)
+ *       [OUTPUT_FILENAME] path to output file
+ *       [RHO] sampling fraction
+ *       [TREEAGE] Tree age (we've hijacked the unneeded number of particles)
+ *
+ */
+
+// Setting parameters/priors
+var filename = argv["_"][1]
+var rho = argv["_"][2]       // "sampling rate" read as a second argument
+                             // because this is the default semantics of npm run wppl
+var startTime = argv["_"][3] // tree age !!! Hijacked number of particles !!! TODO fix this
+
+var stepsize = 1.0  
+var lambda0 =  gamma( {shape: 1, scale: 1} )
+var mu0 =  gamma( {shape: 1, scale: 0.5} )
+var epsilon = mu0 / lambda0
+var sigma = Math.sqrt( 1 / gamma( { shape: 3, scale: 1/startTime } ) )
+var logAlpha = gaussian( {mu: 0, sigma: sigma} ) 
+var alpha = Math.exp(logAlpha) 
+
+// console.log("age = ", startTime)
+// console.log("lambda0 = ", lambda0)
+// console.log("mu0 = ", mu0)
+// console.log("sigma = ", sigma)
+// console.log("alpha = ", alpha)
+// console.log("rho = ", rho)
+// console.log("step size = ", stepsize)
+//console.log("\n")
+
+// GUARDS
+var max_R = 10000 // 500*startTime  A guard against very deep recursions
+var MAX_LAMBDA = 1e12
+var MAX_DIV = 1e12
+var MAX_NODES = 1e12
+
+globalStore.n = 0; // number of nodes
+
+
+// element is a string
+var checkError = function(treeElement) {
+    if (treeElement.includes("ERROR")) {
+	return true
+    } else return false
+}
+
+var anads2TreeSimulate = function( startTime, lambda0, stepsize, logAlpha, sigma, epsilon, rho, max_R  )
+{
+    var Tree = anads2TreeSim( startTime, lambda0, stepsize, logAlpha, sigma, epsilon, rho, max_R );
+    if (Tree == false) {
+	var message = "No survivors."
+	fs.write(filename, message)
+        return(message)
+    }
+    var stringTree = Tree.join(" ")
+    if (stringTree.includes("ERROR")) {
+	var message = "Guards hit. " + stringTree
+	fs.write(filename, message)
+	return(message)
+    }
+    else {
+        var Tree = "(" + stringTree + ")" + ';' ;
+        fs.write(filename, Tree);
+        return Tree
+    }
+}
+
+var anads2TreeSim = function( startTime, lambda, stepsize, logAlpha, sigma, epsilon, rho, max_R )
+{
+    var mu = epsilon * lambda 
+    // extreme values patch
+    if  ( max_R == 0 ) {
+	return ["ERROR_MAX_RECURSION:", startTime]
+    }
+    if ( lambda  > MAX_LAMBDA ) {
+	return ["ERROR_MAX_LAMBDA:", startTime]
+    }
+    if ( lambda - mu  > MAX_DIV ) {
+    	return ["ERROR_MAX_DIV:", startTime]
+    }
+    if ( lambda == 0.0 || mu == 0.0 ) {
+	return ["ERROR_ZERO:", startTime]
+    }
+    if ( globalStore.n > MAX_NODES ) {
+	return ["ERROR_MAX_NODES:", startTime]
+    }
+    //end extreme values patch
+    
+    var timeToSpeciation = exponential( {a: lambda } )
+    var timeToExtinction = exponential( {a: mu } )
+    var timeToAnagenesis = stepsize
+    
+    if (timeToAnagenesis < timeToSpeciation && timeToAnagenesis < timeToExtinction ){
+	//Anagenetic event
+        var currentTime = startTime - timeToAnagenesis;
+        var internalBranch = timeToAnagenesis;
+        var multip = Math.exp(gaussian( {mu: logAlpha*stepsize, sigma: sigma*Math.sqrt(stepsize)}))           // Draw and calc new multiplier
+        var lambdaNew = lambda * multip ;
+        var Tree = anads2TreeSim( currentTime, lambdaNew, stepsize, logAlpha, sigma, epsilon, rho, max_R-1 );         // Continue along branch
+        if (Tree == false ) {             // Extinct/not sampled
+            return false;
+        }
+        else {
+            var newBranch = Tree[1] + internalBranch;           // Add the two "final" branches
+            var NewickTree = [Tree[0] , newBranch ] ;           // build correct final tree
+            return NewickTree;
+        }
+    }
+    
+    else {
+	//Speciation/cladogenetic event
+	var timeToEvent = Math.min(timeToSpeciation, timeToExtinction);
+	var currentTime = startTime - timeToEvent;
+	var internalBranch = timeToEvent; // Calculate length of internal branch leading up to event
+	if ( currentTime < 0 ) { // We have reached the present
+	    globalStore.n = globalStore.n + 1;
+	    	    
+            if ( flip( rho ) ){
+		var Label = uniform(0,1) + ':';            //Survived to present, sampled. Start tree: Set random label to leaf node
+		var NewickTree = [Label , startTime] ;     // Make start on tree
+		return NewickTree;
+            }
+            else {
+		return false;    //Survived to present, but not sampled. Remove branch.
+            }
+	}
+	if ( timeToExtinction == timeToEvent ) {
+            return false;           //Extinct. Remove branch.
+	}
+	else {
+	    // Speciation; first draw values for daughter lineages and then recurse
+            //Anagenetic "update" event at branching point
+            var delta = timeToSpeciation;
+            var multip = Math.exp(gaussian( {mu: logAlpha*delta, sigma: sigma*Math.sqrt(delta)}))         // Draw and calc new multiplier
+            var lambdaNew = lambda * multip ;                                                                // Calculate new lambda
+            //Speciation/cladogenetic event
+            var leftTree  = anads2TreeSim( currentTime, lambdaNew, stepsize, logAlpha, sigma, epsilon, rho, max_R-1 );       // Get back two Newick strings, partial trees
+	    // Check if the left Tree contains an error condition
+	    //	    if (ERROR_STATES.some(error => leftTree.includes(error)) {
+	    if (leftTree == true && leftTree.some(checkError)) {
+		return leftTree; // return only left tree immediately
+	    }
+	 
+            var rightTree = anads2TreeSim( currentTime, lambdaNew, stepsize, logAlpha, sigma, epsilon, rho, max_R-1 );      // Get back two Newick strings, partial trees
+            
+            if (leftTree == false && rightTree == false ) {             // Both sides are extinct/not sampled
+                return false;
+            }
+            if (rightTree == false) {
+                var newBranch = leftTree[1] + internalBranch;       // Add the two branches
+                var NewickTree = [leftTree[0] , newBranch ] ;       // build correct tree without the extinct side
+                return NewickTree ;
+            }
+            if (leftTree  == false ) {
+                var newBranch = rightTree[1] + internalBranch;      // Add the two branches
+                var NewickTree = [rightTree[0] , newBranch ] ;      // build correct tree without the extinct side
+                return NewickTree ;
+            }
+            else {
+                var NewickTree = ['(' + leftTree.join(' ') +', ' + rightTree.join(' ') + ')' + ':' , internalBranch] ;          // Merge trees
+                return NewickTree ;
+            }
+        }
+    }
+}
+
+var message = "Error: MEMORY"
+fs.write(filename, message)
+anads2TreeSimulate( startTime, lambda0, stepsize, logAlpha, sigma, epsilon, rho, max_R )

--- a/phywppl/tree_simulations/treesim-anadsGBM2.wppl
+++ b/phywppl/tree_simulations/treesim-anadsGBM2.wppl
@@ -1,0 +1,148 @@
+/**
+ * Simulation from startTime to the present under AnaDSGBM2, returns observed Tree (without extinctions)
+ *
+ *
+ *
+ * To run the simulation use:
+ * npm run wppl tree_simulations/treesim-anadsGBM2.wppl [N] [OUTPUT_FILENAME] [TREEAGE]
+ *
+ * where [N] is the number of iterations, for example 3
+ *       [OUTPUT_FILENAME] path to output file
+ *       [startTime] Tree age
+ *
+ */
+
+// Setting parameters/priors
+var filename = argv["_"][1]
+var startTime = argv["_"][2]
+var lambda0 = gamma( {shape: 3, scale: 0.1} )
+var mu0 = 0.1
+var epsilon = mu0 / lambda0
+var stepsize = 0.1
+var sigma = Math.sqrt( 1 / gamma( { shape: 1, scale: 1/0.2 } ) )
+var alpha = Math.exp( gaussian( {mu: 0, sigma: sigma} ) )
+var rho = 1
+// GUARDS
+var MAX_LAMBDA = 20
+var MAX_DIV = 20
+
+
+var anads2TreeSimulate= function( startTime, lambda0, stepsize, alpha, sigma, epsilon, rho  )
+{
+    var Tree = anads2TreeSim( startTime, lambda0, stepsize, alpha, sigma, epsilon, rho );
+    if (Tree == false) {
+        return("No survivors")
+    }
+    var Tree1 = Tree.join(" ") ;
+    var infiniteTree = Tree1.includes("Infinity:")
+    if (infiniteTree == true) {
+        return("Error: Tree has infinite parts - the maximum guard was activated")
+    }
+    var zeroTree = Tree1.includes("Zero:")
+    if (zeroTree == true) {
+        return("Error: Tree has parts where the minimum guard on lambda was activated")
+    }
+    else {
+        var Tree = Tree.join('') + ';' ;
+        fs.write(filename, Tree);
+        return Tree
+    }
+}
+
+ 
+ var anads2TreeSim = function( startTime, lambda, stepsize, alpha, sigma, epsilon, rho )
+{
+    var mu = epsilon * lambda
+    
+    // extreme values patch
+    if ( lambda  > MAX_LAMBDA ) {
+        var Label = 'Infinity:';            //Indicate infinite tree on this branch
+        var NewickTree = [Label , startTime] ;     // Make start on tree
+        return NewickTree;
+        }
+    if ( lambda - mu  > MAX_DIV ) {
+        var Label = 'Infinity:';            //Indicate infinite tree on this branch
+        var NewickTree = [Label , startTime] ;     // Make start on tree
+        return NewickTree;
+        }
+    if ( lambda == 0.0 ) {
+        var Label = 'Zero:';            //Indicate lambda=0 on this branch
+        var NewickTree = [Label , startTime] ;     // Make start on tree
+        return NewickTree;
+    }
+    // end extreme values patch
+
+    var timeToSpeciation = exponential( {a: lambda } )
+    var timeToExtinction = exponential( {a: mu } )
+    var timeToAnagenesis = stepsize
+    
+    if (timeToAnagenesis < timeToSpeciation && timeToAnagenesis < timeToExtinction ){
+    //Anagenetic event
+        var currentTime = startTime - timeToAnagenesis;
+        var internalBranch = timeToAnagenesis;
+        var multip = Math.exp(gaussian( {mu: alpha*stepsize, sigma: sigma*stepsize}))           // Draw and calc new multiplier
+        var lambdaNew = lambda * multip ;
+        var Tree = anads2TreeSim( currentTime, lambdaNew, stepsize, alpha, sigma, epsilon, rho );         // Continue along branch
+        if (Tree == false ) {             // Extinct/not sampled
+                return false;
+        }
+        else {
+        var newBranch = Tree[1] + internalBranch;           // Add the two "final" branches
+        var NewickTree = [Tree[0] , newBranch ] ;           // build correct final tree
+        return NewickTree;
+        }
+    }
+    
+    else {
+    //Speciation/cladogenetic event
+    var timeToEvent = Math.min(timeToSpeciation, timeToExtinction);
+    var currentTime = startTime - timeToEvent;
+    var internalBranch = timeToEvent;    // Calculate length of internal branch leading up to event
+    if ( currentTime < 0 )
+    // We have reached the present
+    {
+        if ( flip( rho ) ){
+            var Label = uniform(0,1) + ':';            //Survived to present, sampled. Start tree: Set random label to leaf node
+            var NewickTree = [Label , startTime] ;     // Make start on tree
+            return NewickTree;
+        }
+        else {
+            return false;    //Survived to present, but not sampled. Remove branch.
+        }
+    }
+    if ( timeToExtinction == timeToEvent ) {
+        return false;           //Extinct. Remove branch.
+    }
+    else {
+    // Speciation; first draw values for daughter lineages and then recurse
+        //Anagenetic "update" event at branching point
+        var delta = timeToSpeciation;
+        var multip = Math.exp(gaussian( {mu: alpha*delta, sigma: sigma*delta}))         // Draw and calc new multiplier
+        var lambdaNew = lambda * multip ;                                                                // Calculate new lambda
+        //Speciation/cladogenetic event
+        var leftTree  = anads2TreeSim( currentTime, lambdaNew, stepsize, alpha, sigma, epsilon, rho );       // Get back two Newick strings, partial trees
+        var rightTree = anads2TreeSim( currentTime, lambdaNew, stepsize, alpha, sigma, epsilon, rho );      // Get back two Newick strings, partial trees
+        
+        if (leftTree == false && rightTree == false ) {             // Both sides are extinct/not sampled
+                return false;
+            }
+        if (rightTree == false) {
+                var newBranch = leftTree[1] + internalBranch;       // Add the two branches
+                var NewickTree = [leftTree[0] , newBranch ] ;       // build correct tree without the extinct side
+                return NewickTree ;
+            }
+        if (leftTree  == false ) {
+                var newBranch = rightTree[1] + internalBranch;      // Add the two branches
+                var NewickTree = [rightTree[0] , newBranch ] ;      // build correct tree without the extinct side
+                return NewickTree ;
+            }
+        else {
+                var NewickTree = ['(' + leftTree.join('') +',' + rightTree.join('') + ')' + ':' , internalBranch] ;          // Merge trees
+                return NewickTree ;
+            }
+        }
+    }
+}
+
+
+anads2TreeSimulate( startTime, lambda0, stepsize, alpha, sigma, epsilon, rho )

--- a/phywppl/tree_simulations/treesim-anadsGBM2.wppl
+++ b/phywppl/tree_simulations/treesim-anadsGBM2.wppl
@@ -14,22 +14,23 @@
 
 // Setting parameters/priors
 var filename = argv["_"][1]
-var startTime = argv["_"][2]
-var lambda0 = gamma( {shape: 3, scale: 0.1} )
-var mu0 = 0.1
+var startTime = argv["_"][2] // Tree age
+var lambda0 = 0.2// gamma( {shape: 1, scale: 1} )
+var mu0 = 0.1// gamma( {shape: 1, scale: 0.5} )
 var epsilon = mu0 / lambda0
-var stepsize = 0.1
-var sigma = Math.sqrt( 1 / gamma( { shape: 1, scale: 1/0.2 } ) )
-var alpha = Math.exp( gaussian( {mu: 0, sigma: sigma} ) )
+var stepsize = 0.2
+var sigma = 0.00001 //Math.sqrt( 1 / gamma( { shape: 3, scale: 1/startTime } ) )
+var alpha = 1 //Math.exp( gaussian( {mu: 0, sigma: sigma} ) )
 var rho = 1
 // GUARDS
 var MAX_LAMBDA = 20
 var MAX_DIV = 20
+var max_R = 1000 //50*startTime // A guard against very deep recursions
 
 
-var anads2TreeSimulate= function( startTime, lambda0, stepsize, alpha, sigma, epsilon, rho  )
+var anads2TreeSimulate= function( startTime, lambda0, stepsize, alpha, sigma, epsilon, rho, max_R  )
 {
-    var Tree = anads2TreeSim( startTime, lambda0, stepsize, alpha, sigma, epsilon, rho );
+    var Tree = anads2TreeSim( startTime, lambda0, stepsize, alpha, sigma, epsilon, rho, max_R );
     if (Tree == false) {
         return("No survivors")
     }
@@ -42,6 +43,10 @@ var anads2TreeSimulate= function( startTime, lambda0, stepsize, alpha, sigma, ep
     if (zeroTree == true) {
         return("Error: Tree has parts where the minimum guard on lambda was activated")
     }
+    var zeroTree = Tree1.includes("NaN:")
+    if (zeroTree == true) {
+        return("Error: Guard on max number of recursions was activated")
+    }
     else {
         var Tree = Tree.join('') + ';' ;
         fs.write(filename, Tree);
@@ -50,11 +55,18 @@ var anads2TreeSimulate= function( startTime, lambda0, stepsize, alpha, sigma, ep
 }
 
  
- var anads2TreeSim = function( startTime, lambda, stepsize, alpha, sigma, epsilon, rho )
+ var anads2TreeSim = function( startTime, lambda, stepsize, alpha, sigma, epsilon, rho, max_R )
 {
+    display(lambda) //Debugging
     var mu = epsilon * lambda
-    
+    display(mu) //Debugging
     // extreme values patch
+    if  ( max_R == 0 ) {
+        display("NaN");
+        var Label = 'NaN:';            //Indicate infinite tree on this branch
+        var NewickTree = [Label , startTime] ;     // Make start on tree
+        return NewickTree;
+        }
     if ( lambda  > MAX_LAMBDA ) {
         var Label = 'Infinity:';            //Indicate infinite tree on this branch
         var NewickTree = [Label , startTime] ;     // Make start on tree
@@ -82,7 +94,7 @@ var anads2TreeSimulate= function( startTime, lambda0, stepsize, alpha, sigma, ep
         var internalBranch = timeToAnagenesis;
         var multip = Math.exp(gaussian( {mu: alpha*stepsize, sigma: sigma*stepsize}))           // Draw and calc new multiplier
         var lambdaNew = lambda * multip ;
-        var Tree = anads2TreeSim( currentTime, lambdaNew, stepsize, alpha, sigma, epsilon, rho );         // Continue along branch
+        var Tree = anads2TreeSim( currentTime, lambdaNew, stepsize, alpha, sigma, epsilon, rho, max_R-1 );         // Continue along branch
         if (Tree == false ) {             // Extinct/not sampled
                 return false;
         }
@@ -120,8 +132,8 @@ var anads2TreeSimulate= function( startTime, lambda0, stepsize, alpha, sigma, ep
         var multip = Math.exp(gaussian( {mu: alpha*delta, sigma: sigma*delta}))         // Draw and calc new multiplier
         var lambdaNew = lambda * multip ;                                                                // Calculate new lambda
         //Speciation/cladogenetic event
-        var leftTree  = anads2TreeSim( currentTime, lambdaNew, stepsize, alpha, sigma, epsilon, rho );       // Get back two Newick strings, partial trees
-        var rightTree = anads2TreeSim( currentTime, lambdaNew, stepsize, alpha, sigma, epsilon, rho );      // Get back two Newick strings, partial trees
+        var leftTree  = anads2TreeSim( currentTime, lambdaNew, stepsize, alpha, sigma, epsilon, rho, max_R-1 );       // Get back two Newick strings, partial trees
+        var rightTree = anads2TreeSim( currentTime, lambdaNew, stepsize, alpha, sigma, epsilon, rho, max_R-1 );      // Get back two Newick strings, partial trees
         
         if (leftTree == false && rightTree == false ) {             // Both sides are extinct/not sampled
                 return false;
@@ -145,4 +157,4 @@ var anads2TreeSimulate= function( startTime, lambda0, stepsize, alpha, sigma, ep
 }
 
 
-anads2TreeSimulate( startTime, lambda0, stepsize, alpha, sigma, epsilon, rho )
+anads2TreeSimulate( startTime, lambda0, stepsize, alpha, sigma, epsilon, rho, max_R )

--- a/phywppl/tree_simulations/treesim-clads0.wppl
+++ b/phywppl/tree_simulations/treesim-clads0.wppl
@@ -30,11 +30,12 @@ var clads0TreeSimulate= function( startTime, lambda, alpha, sigma, rho, multip  
     if (Tree == false) {
         return("No survivors")
     }
-    var infiniteTree = Tree.includes("Infinity:")
+    var Tree1 = Tree.join(" ") ;
+    var infiniteTree = Tree1.includes("Infinity:")
     if (infiniteTree == true) {
         return("Error: Tree has infinite parts - the maximum guard on lambda was activated")
     }
-    var zeroTree = Tree.includes("Zero:")
+    var zeroTree = Tree1.includes("Zero:")
     if (zeroTree == true) {
         return("Error: Tree has parts where the minimum guard on lambda was activated")
     }
@@ -63,7 +64,7 @@ var clads0TreeSimulate= function( startTime, lambda, alpha, sigma, rho, multip  
 
     var t = exponential( {a: lambda } )
     var currentTime = startTime - t
-    var internalBranch = startTime - currentTime;    // Calculate length of internal branch leading up to event
+    var internalBranch = t;    // Calculate length of internal branch leading up to event
     if ( currentTime < 0 )     // If we have reached the present...
     {
         if ( flip( rho ) ){
@@ -78,8 +79,8 @@ var clads0TreeSimulate= function( startTime, lambda, alpha, sigma, rho, multip  
     else {
 
     // Speciation; first draw values for daughter lineages and then recurse
-        var multip1 = multip * Math.exp(gaussian( {mu: alpha, sigma: sigma}))  // Draw and calc new multiplier set for daughter1
-        var multip2 = multip * Math.exp(gaussian( {mu: alpha, sigma: sigma}))  // Draw and calc new multiplier set for daughter2
+        var multip1 = Math.exp(gaussian( {mu: alpha, sigma: sigma}))  // Draw and calc new multiplier set for daughter1
+        var multip2 = Math.exp(gaussian( {mu: alpha, sigma: sigma}))  // Draw and calc new multiplier set for daughter2
         var lambda1 = lambda * multip1                                // Calculate new lambda for daughter1
         var lambda2 = lambda * multip2                                // Calculate new lambda for daughter2
         

--- a/phywppl/tree_simulations/treesim-clads0.wppl
+++ b/phywppl/tree_simulations/treesim-clads0.wppl
@@ -80,8 +80,8 @@ var clads0TreeSimulate= function( startTime, lambda, alpha, sigma, rho, multip  
     // Speciation; first draw values for daughter lineages and then recurse
         var multip1 = multip * Math.exp(gaussian( {mu: alpha, sigma: sigma}))  // Draw and calc new multiplier set for daughter1
         var multip2 = multip * Math.exp(gaussian( {mu: alpha, sigma: sigma}))  // Draw and calc new multiplier set for daughter2
-        var lambda1 = 0.2 * multip1                                // Calculate new lambda for daughter1
-        var lambda2 = 0.2 * multip2                                // Calculate new lambda for daughter2
+        var lambda1 = lambda * multip1                                // Calculate new lambda for daughter1
+        var lambda2 = lambda * multip2                                // Calculate new lambda for daughter2
         
         var leftTree  = clads0TreeSim( currentTime, lambda1, alpha, sigma, rho, multip1 );       // Get back two Newick strings, partial trees
         var rightTree = clads0TreeSim( currentTime, lambda2, alpha, sigma, rho, multip2 );      // Get back two Newick strings, partial trees

--- a/phywppl/tree_simulations/treesim-clads0.wppl
+++ b/phywppl/tree_simulations/treesim-clads0.wppl
@@ -1,0 +1,111 @@
+/**
+ * Simulation from startTime to the present under ClaDS0, returns observed Tree (without extinctions)
+ *
+ *
+ *
+ * To run the simulation use:
+ * npm run wppl tree_simulations/treesim-clads0.wppl [N] [OUTPUT_FILENAME] [TREEAGE] [LAMBDA0]
+ *
+ * where [N] is the number of iterations, for example 3
+ *       [OUTPUT_FILENAME] path to output file
+ *       [startTime] Tree age
+ *       [LAMBDA0] value of lambda at the start of the simulation
+ *
+ */
+
+var filename = argv["_"][1]
+var startTime = argv["_"][2]
+var lambda0 = argv["_"][3]
+var alpha = Math.log(0.95)
+var sigma = 0.1
+var multip = 1
+var rho = 1
+// GUARD
+var MAX_LAMBDA = 20
+
+
+var clads0TreeSimulate= function( startTime, lambda, alpha, sigma, rho, multip  )
+{
+    var Tree = clads0TreeSim( startTime, lambda, alpha, sigma, rho, multip );
+    if (Tree == false) {
+        return("No survivors")
+    }
+    var infiniteTree = Tree.includes("Infinity:")
+    if (infiniteTree == true) {
+        return("Error: Tree has infinite parts - the maximum guard on lambda was activated")
+    }
+    var zeroTree = Tree.includes("Zero:")
+    if (zeroTree == true) {
+        return("Error: Tree has parts where the minimum guard on lambda was activated")
+    }
+    else {
+        var Tree = Tree.join('') + ';' ;
+        fs.write(filename, Tree);
+        return Tree
+    }
+}
+
+ 
+ var clads0TreeSim = function( startTime, lambda, alpha, sigma, rho, multip )
+{
+    // extreme values patch
+    if ( lambda  > phyjs.MAX_LAMBDA ) {
+        var Label = 'Infinity:';            //Indicate infinite tree on this branch
+        var NewickTree = [Label , startTime] ;     // Make start on tree
+        return NewickTree;
+        }
+    if ( lambda == 0.0 ) {
+        var Label = 'Zero:';            //Indicate lambda=0 on this branch
+        var NewickTree = [Label , startTime] ;     // Make start on tree
+        return NewickTree;
+    }
+    // end extreme values patch
+
+    var t = exponential( {a: lambda } )
+    var currentTime = startTime - t
+    var internalBranch = startTime - currentTime;    // Calculate length of internal branch leading up to event
+    if ( currentTime < 0 )     // If we have reached the present...
+    {
+        if ( flip( rho ) ){
+            var Label = uniform(0,1) + ':';            //Survived to present, sampled. Start tree: Set random label to leaf node
+            var NewickTree = [Label , startTime] ;     // Make start on tree
+            return NewickTree;
+        }
+        else {
+            return false;    //Survived to present, but not sampled. Remove branch.
+        }
+    }
+    else {
+
+    // Speciation; first draw values for daughter lineages and then recurse
+        var multip1 = multip * Math.exp(gaussian( {mu: alpha, sigma: sigma}))  // Draw and calc new multiplier set for daughter1
+        var multip2 = multip * Math.exp(gaussian( {mu: alpha, sigma: sigma}))  // Draw and calc new multiplier set for daughter2
+        var lambda1 = 0.2 * multip1                                // Calculate new lambda for daughter1
+        var lambda2 = 0.2 * multip2                                // Calculate new lambda for daughter2
+        
+        var leftTree  = clads0TreeSim( currentTime, lambda1, alpha, sigma, rho, multip1 );       // Get back two Newick strings, partial trees
+        var rightTree = clads0TreeSim( currentTime, lambda2, alpha, sigma, rho, multip2 );      // Get back two Newick strings, partial trees
+        
+        if (leftTree == false && rightTree == false ) {             // Both sides are extinct/not sampled
+                return false;
+            }
+        if (rightTree == false) {
+                var newBranch = leftTree[1] + internalBranch;       // Add the two branches
+                var NewickTree = [leftTree[0] , newBranch ] ;       // build correct tree without the extinct side
+                return NewickTree ;
+            }
+        if (leftTree  == false ) {
+                var newBranch = rightTree[1] + internalBranch;      // Add the two branches
+                var NewickTree = [rightTree[0] , newBranch ] ;      // build correct tree without the extinct side
+                return NewickTree ;
+            }
+        else {
+                var NewickTree = ['(' + leftTree.join('') +',' + rightTree.join('') + ')' + ':' , internalBranch] ;          // Merge trees
+                return NewickTree ;
+            }
+    }
+    
+}
+
+
+clads0TreeSimulate( startTime, lambda0, alpha, sigma, rho, multip )

--- a/phywppl/tree_simulations/treesim-clads1.wppl
+++ b/phywppl/tree_simulations/treesim-clads1.wppl
@@ -34,11 +34,12 @@ var clads1TreeSimulate= function( startTime, lambda, alpha, sigma, mu, rho, mult
     if (Tree == false) {
         return("No survivors")
     }
-    var infiniteTree = Tree.includes("Infinity:")
+    var Tree1 = Tree.join(" ") ;
+    var infiniteTree = Tree1.includes("Infinity:")
     if (infiniteTree == true) {
         return("Error: Tree has infinite parts - the maximum guard was activated")
     }
-    var zeroTree = Tree.includes("Zero:")
+    var zeroTree = Tree1.includes("Zero:")
     if (zeroTree == true) {
         return("Error: Tree has parts where the minimum guard on lambda was activated")
     }
@@ -72,7 +73,7 @@ var clads1TreeSimulate= function( startTime, lambda, alpha, sigma, mu, rho, mult
 
     var t = exponential( {a: lambda + mu } )
     var currentTime = startTime - t
-    var internalBranch = startTime - currentTime;    // Calculate length of internal branch leading up to event
+    var internalBranch = t;    // Calculate length of internal branch leading up to event
     if ( currentTime < 0 )     // If we have reached the present...
     {
         if ( flip( rho ) ){

--- a/phywppl/tree_simulations/treesim-clads1.wppl
+++ b/phywppl/tree_simulations/treesim-clads1.wppl
@@ -1,0 +1,122 @@
+/**
+ * Simulation from startTime to the present under ClaDS1, returns observed Tree (without extinctions)
+ *
+ *
+ *
+ * To run the simulation use:
+ * npm run wppl tree_simulations/treesim-clads1.wppl [N] [OUTPUT_FILENAME] [TREEAGE] [LAMBDA0]
+ *
+ * where [N] is the number of iterations, for example 3
+ *       [OUTPUT_FILENAME] path to output file
+ *       [startTime] Tree age
+ *       [LAMBDA0] value of lambda at the start of the simulation
+ *
+ */
+
+// Setting variables/priors
+var filename = argv["_"][1]
+var startTime = argv["_"][2]
+var lambda0 = argv["_"][3]
+var mu = 0.1
+var alpha = Math.log(0.95)
+var sigma = 0.1
+var multip = 1
+var rho = 1
+
+// GUARDS
+var MAX_LAMBDA = 20
+var MAX_DIV = 20
+
+
+var clads1TreeSimulate= function( startTime, lambda, alpha, sigma, mu, rho, multip  )
+{
+    var Tree = clads1TreeSim( startTime, lambda0, lambda0, alpha, sigma, mu, rho, multip );
+    if (Tree == false) {
+        return("No survivors")
+    }
+    var infiniteTree = Tree.includes("Infinity:")
+    if (infiniteTree == true) {
+        return("Error: Tree has infinite parts - the maximum guard was activated")
+    }
+    var zeroTree = Tree.includes("Zero:")
+    if (zeroTree == true) {
+        return("Error: Tree has parts where the minimum guard on lambda was activated")
+    }
+    else {
+        var Tree = Tree.join('') + ';' ;
+        fs.write(filename, Tree);
+        return Tree
+    }
+}
+
+ 
+ var clads1TreeSim = function( startTime, lambda0, lambda, alpha, sigma, mu, rho, multip )
+{
+    // extreme values patch
+    if ( lambda  > phyjs.MAX_LAMBDA ) {
+        var Label = 'Infinity:';            //Indicate infinite tree on this branch
+        var NewickTree = [Label , startTime] ;     // Make start on tree
+        return NewickTree;
+        }
+    if ( lambda - mu  > phyjs.MAX_DIV ) {
+        var Label = 'Infinity:';            //Indicate infinite tree on this branch
+        var NewickTree = [Label , startTime] ;     // Make start on tree
+        return NewickTree;
+        }
+    if ( lambda == 0.0 ) {
+        var Label = 'Zero:';            //Indicate lambda=0 on this branch
+        var NewickTree = [Label , startTime] ;     // Make start on tree
+        return NewickTree;
+    }
+    // end extreme values patch
+
+    var t = exponential( {a: lambda + mu } )
+    var currentTime = startTime - t
+    var internalBranch = startTime - currentTime;    // Calculate length of internal branch leading up to event
+    if ( currentTime < 0 )     // If we have reached the present...
+    {
+        if ( flip( rho ) ){
+            var Label = uniform(0,1) + ':';            //Survived to present, sampled. Start tree: Set random label to leaf node
+            var NewickTree = [Label , startTime] ;     // Make start on tree
+            return NewickTree;
+        }
+        else {
+            return false;    //Survived to present, but not sampled. Remove branch.
+        }
+    }
+    
+    var extinction = flip( mu/(mu+lambda) )
+    if ( extinction )
+        return false;           //Extinct. Remove branch.
+    
+    // Otherwise: Speciation; first draw values for daughter lineages and then recurse
+        var multip1 = multip * Math.exp(gaussian( {mu: alpha, sigma: sigma}))  // Draw and calc new multiplier set for daughter1
+        var multip2 = multip * Math.exp(gaussian( {mu: alpha, sigma: sigma}))  // Draw and calc new multiplier set for daughter2
+        var lambda1 = lambda0 * multip1                                // Calculate new lambda for daughter1
+        var lambda2 = lambda0 * multip2                                // Calculate new lambda for daughter2
+        
+        var leftTree  = clads1TreeSim( currentTime, lambda0, lambda1, alpha, sigma, mu, rho, multip1 );       // Get back two Newick strings, partial trees
+        var rightTree = clads1TreeSim( currentTime, lambda0, lambda2, alpha, sigma, mu, rho, multip2 );      // Get back two Newick strings, partial trees
+        
+        if (leftTree == false && rightTree == false ) {             // Both sides are extinct/not sampled
+                return false;
+            }
+        if (rightTree == false) {
+                var newBranch = leftTree[1] + internalBranch;       // Add the two branches
+                var NewickTree = [leftTree[0] , newBranch ] ;       // build correct tree without the extinct side
+                return NewickTree ;
+            }
+        if (leftTree  == false ) {
+                var newBranch = rightTree[1] + internalBranch;      // Add the two branches
+                var NewickTree = [rightTree[0] , newBranch ] ;      // build correct tree without the extinct side
+                return NewickTree ;
+            }
+        else {
+                var NewickTree = ['(' + leftTree.join('') +',' + rightTree.join('') + ')' + ':' , internalBranch] ;          // Merge trees
+                return NewickTree ;
+            }
+    
+}
+
+
+clads1TreeSimulate( startTime, lambda0, alpha, sigma, mu, rho, multip )

--- a/phywppl/tree_simulations/treesim-clads2.wppl
+++ b/phywppl/tree_simulations/treesim-clads2.wppl
@@ -1,0 +1,125 @@
+/**
+ * Simulation from startTime to the present under ClaDS2, returns observed Tree (without extinctions)
+ *
+ *
+ *
+ * To run the simulation use:
+ * npm run wppl tree_simulations/treesim-clads2.wppl [N] [OUTPUT_FILENAME] [TREEAGE] [LAMBDA0]
+ *
+ * where [N] is the number of iterations, for example 3
+ *       [OUTPUT_FILENAME] path to output file
+ *       [startTime] Tree age
+ *       [LAMBDA0] value of lambda at the start of the simulation
+ *
+ */
+
+// Setting variables/priors
+var filename = argv["_"][1]
+var startTime = argv["_"][2]
+var lambda0 = argv["_"][3]
+var mu0 = 0.1
+var epsilon = mu0 / lambda0
+var alpha = Math.log(0.95)
+var sigma = 0.1
+var multip = 1
+var rho = 1
+
+// GUARDS
+var MAX_LAMBDA = 20
+var MAX_DIV = 20
+
+
+var clads2TreeSimulate= function( startTime, lambda0, alpha, sigma, epsilon, rho, multip  )
+{
+    var Tree = clads2TreeSim( startTime, lambda0, lambda0, alpha, sigma, epsilon, rho, multip );
+    if (Tree == false) {
+        return("No survivors")
+    }
+    var infiniteTree = Tree.includes("Infinity:")
+    if (infiniteTree == true) {
+        return("Error: Tree has infinite parts - the maximum guard was activated")
+    }
+    var zeroTree = Tree.includes("Zero:")
+    if (zeroTree == true) {
+        return("Error: Tree has parts where the minimum guard on lambda was activated")
+    }
+    else {
+        var Tree = Tree.join('') + ';' ;
+        fs.write(filename, Tree);
+        return Tree
+    }
+}
+
+ 
+ var clads2TreeSim = function( startTime, lambda0, lambda, alpha, sigma, epsilon, rho, multip )
+{
+    var mu = epsilon * lambda
+    
+    // extreme values patch
+    if ( lambda  > phyjs.MAX_LAMBDA ) {
+        var Label = 'Infinity:';            //Indicate infinite tree on this branch
+        var NewickTree = [Label , startTime] ;     // Make start on tree
+        return NewickTree;
+        }
+    if ( lambda - mu  > phyjs.MAX_DIV ) {
+        var Label = 'Infinity:';            //Indicate infinite tree on this branch
+        var NewickTree = [Label , startTime] ;     // Make start on tree
+        return NewickTree;
+        }
+    if ( lambda == 0.0 ) {
+        var Label = 'Zero:';            //Indicate lambda=0 on this branch
+        var NewickTree = [Label , startTime] ;     // Make start on tree
+        return NewickTree;
+    }
+    // end extreme values patch
+
+    var t = exponential( {a: lambda + mu } )
+    var currentTime = startTime - t
+    var internalBranch = startTime - currentTime;    // Calculate length of internal branch leading up to event
+    if ( currentTime < 0 )     // If we have reached the present...
+    {
+        if ( flip( rho ) ){
+            var Label = uniform(0,1) + ':';            //Survived to present, sampled. Start tree: Set random label to leaf node
+            var NewickTree = [Label , startTime] ;     // Make start on tree
+            return NewickTree;
+        }
+        else {
+            return false;    //Survived to present, but not sampled. Remove branch.
+        }
+    }
+    
+    var extinction = flip( mu/(mu+lambda) )
+    if ( extinction )
+        return false;           //Extinct. Remove branch.
+    
+    // Otherwise: Speciation; first draw values for daughter lineages and then recurse
+        var multip1 = multip * Math.exp(gaussian( {mu: alpha, sigma: sigma}))  // Draw and calc new multiplier set for daughter1
+        var multip2 = multip * Math.exp(gaussian( {mu: alpha, sigma: sigma}))  // Draw and calc new multiplier set for daughter2
+        var lambda1 = lambda0 * multip1                                // Calculate new lambda for daughter1
+        var lambda2 = lambda0 * multip2                                // Calculate new lambda for daughter2
+        
+        var leftTree  = clads2TreeSim( currentTime, lambda0, lambda1, alpha, sigma, epsilon, rho, multip1 );       // Get back two Newick strings, partial trees
+        var rightTree = clads2TreeSim( currentTime, lambda0, lambda2, alpha, sigma, epsilon, rho, multip2 );      // Get back two Newick strings, partial trees
+        
+        if (leftTree == false && rightTree == false ) {             // Both sides are extinct/not sampled
+                return false;
+            }
+        if (rightTree == false) {
+                var newBranch = leftTree[1] + internalBranch;       // Add the two branches
+                var NewickTree = [leftTree[0] , newBranch ] ;       // build correct tree without the extinct side
+                return NewickTree ;
+            }
+        if (leftTree  == false ) {
+                var newBranch = rightTree[1] + internalBranch;      // Add the two branches
+                var NewickTree = [rightTree[0] , newBranch ] ;      // build correct tree without the extinct side
+                return NewickTree ;
+            }
+        else {
+                var NewickTree = ['(' + leftTree.join('') +',' + rightTree.join('') + ')' + ':' , internalBranch] ;          // Merge trees
+                return NewickTree ;
+            }
+    
+}
+
+
+clads2TreeSimulate( startTime, lambda0, alpha, sigma, epsilon, rho, multip )

--- a/phywppl/tree_simulations/treesim-clads2.wppl
+++ b/phywppl/tree_simulations/treesim-clads2.wppl
@@ -35,11 +35,12 @@ var clads2TreeSimulate= function( startTime, lambda0, alpha, sigma, epsilon, rho
     if (Tree == false) {
         return("No survivors")
     }
-    var infiniteTree = Tree.includes("Infinity:")
+    var Tree1 = Tree.join(" ") ;
+    var infiniteTree = Tree1.includes("Infinity:")
     if (infiniteTree == true) {
         return("Error: Tree has infinite parts - the maximum guard was activated")
     }
-    var zeroTree = Tree.includes("Zero:")
+    var zeroTree = Tree1.includes("Zero:")
     if (zeroTree == true) {
         return("Error: Tree has parts where the minimum guard on lambda was activated")
     }
@@ -75,7 +76,7 @@ var clads2TreeSimulate= function( startTime, lambda0, alpha, sigma, epsilon, rho
 
     var t = exponential( {a: lambda + mu } )
     var currentTime = startTime - t
-    var internalBranch = startTime - currentTime;    // Calculate length of internal branch leading up to event
+    var internalBranch = t;    // Calculate length of internal branch leading up to event
     if ( currentTime < 0 )     // If we have reached the present...
     {
         if ( flip( rho ) ){


### PR DESCRIPTION
Guards fixed on tree simulations for clads0,1,2. 
- If lambda =0, lambda > max, or if lambda-mu > max, error messages are given and no tree is printed to file. 
With the relevant prior settings these simulators (plus the crbd ones) should be ready to use now. 

Plus bug fixes in clads0 model from before. 